### PR TITLE
Add camera zoom and pan controls

### DIFF
--- a/characters/player_camera.gd
+++ b/characters/player_camera.gd
@@ -1,0 +1,89 @@
+class_name PlayerCamera
+extends Camera2D
+
+# zoom vars
+@export var zoom_max = Vector2(.7, .7)
+@export var zoom_min = Vector2(3, 3)
+@export var zoom_lerp_speed = 4.0
+@export var zoom_speed = .5
+@export var zoom_total_time = 1
+
+var zoom_out = false
+var zoom_in = false
+
+var time_lerping := 0.0
+var target_zoom: Vector2
+
+# pan vars
+@export var pan_lerp_speed: float = 4
+@export var pan_grab_frames: int = 4
+@export var pan_velocity_dampening_factor: float = 5
+@export var pan_velocity_div_factor: float = 150
+
+var pan_grab_pos: Vector2
+var panning: bool
+var pan_velocity: Vector2
+var pos_holder: Array = []
+
+func _unhandled_input(event: InputEvent):
+	if Input.is_action_just_released("zoom_out") and zoom > zoom_max:
+		zoom_out = true
+		zoom_in = false
+		target_zoom = zoom - Vector2(zoom_speed, zoom_speed)
+		time_lerping = 0
+	if Input.is_action_just_released("zoom_in") and zoom < zoom_min:
+		zoom_in = true
+		zoom_out = false
+		target_zoom = zoom + Vector2(zoom_speed, zoom_speed)
+		time_lerping = 0
+
+	if Input.is_action_just_pressed("camera_pan_grab"):
+		panning = true
+		pan_grab_pos = event.position
+		pan_velocity = Vector2.ZERO
+		pos_holder.clear()
+	elif Input.is_action_just_released("camera_pan_grab"):
+		if panning and pan_velocity != Vector2.ZERO:
+			pan_velocity = pan_velocity.normalized() * (pan_velocity.length() / pan_velocity_div_factor)
+			
+		panning = false
+
+	if Input.is_action_just_pressed("center_player"):
+		offset = Vector2.ZERO
+		pan_velocity = Vector2.ZERO
+
+
+func _physics_process(delta: float):
+	if panning:
+		var curr_mouse_pos = get_viewport().get_mouse_position()
+
+		# keep track of mouse pos for $pan_grab_frames to generate a velocity
+		# vector for the camera once "camera_pan_grab" is released
+		# done in _physics_process so that FPS doesn't impact the pan velocity
+		pos_holder.push_back(curr_mouse_pos)
+		if len(pos_holder) == pan_grab_frames + 1:
+			pos_holder.pop_front()
+		pan_velocity = pos_holder[0] - pos_holder[len(pos_holder) - 1]
+
+
+func _process(delta):
+	if zoom_out == true and zoom >= zoom_max:
+		time_lerping += delta
+		zoom = zoom.slerp(target_zoom, zoom_lerp_speed * delta)
+		if time_lerping >= zoom_total_time:
+			zoom_out = false
+
+	if zoom_in == true and zoom <= zoom_min:
+		time_lerping += delta
+		zoom = zoom.slerp(target_zoom, zoom_lerp_speed * delta)
+		if time_lerping >= zoom_total_time:
+			zoom_out = false
+
+	if panning:
+		var curr_mouse_pos = get_viewport().get_mouse_position()
+		offset += pan_grab_pos - curr_mouse_pos
+		pan_grab_pos = curr_mouse_pos
+
+	if not panning:
+		offset += pan_velocity
+		pan_velocity = pan_velocity.slerp(Vector2.ZERO, pan_velocity_dampening_factor * delta)

--- a/characters/player_camera.gd
+++ b/characters/player_camera.gd
@@ -2,16 +2,19 @@ class_name PlayerCamera
 extends Camera2D
 
 # zoom vars
-@export var zoom_max = Vector2(.7, .7)
-@export var zoom_min = Vector2(3, 3)
-@export var zoom_lerp_speed = 4.0
-@export var zoom_speed = .5
-@export var zoom_total_time = 1
+@export var zoom_max: Vector2 = Vector2(.7, .7)
+@export var zoom_min: Vector2 = Vector2(3, 3)
+@export var zoom_lerp_speed: float = 4.0
+@export var zoom_speed: float = .5
+@export var zoom_total_time: float = 1
 
-var zoom_out = false
-var zoom_in = false
+var starting_zoom: Vector2 = Vector2(zoom.x, zoom.y)
+var zoom_out: bool = false
+var zoom_in: bool = false
 
-var time_lerping := 0.0
+var zoom_triggered: bool = false
+
+var time_lerping: float = 0.0
 var target_zoom: Vector2
 
 # pan vars
@@ -24,19 +27,34 @@ var pan_grab_pos: Vector2
 var panning: bool
 var pan_velocity: Vector2
 var pos_holder: Array = []
+var camera_pan_vec: Vector2 
+var camera_pan_vec_div_factor: float = 3 
+
 
 func _unhandled_input(event: InputEvent):
-	if Input.is_action_just_released("zoom_out") and zoom > zoom_max:
+	# zoom controls:
+	# zoom_out -> mouse wheel down
+	# zoom_trigger -> L2 + zoom_out_trigger -> right stick down
+	if ((Input.is_action_just_released("zoom_out") or 
+		  (Input.is_action_pressed("zoom_trigger") and Input.is_action_pressed("zoom_out_trigger")))
+		  and zoom > zoom_max):
 		zoom_out = true
 		zoom_in = false
 		target_zoom = zoom - Vector2(zoom_speed, zoom_speed)
 		time_lerping = 0
-	if Input.is_action_just_released("zoom_in") and zoom < zoom_min:
+
+	# zoom_in -> mouse wheel up
+	# zoom_trigger -> L2 + zoom_in_trigger -> right stick up
+	if ((Input.is_action_just_released("zoom_in") or 
+		  (Input.is_action_pressed("zoom_trigger") and Input.is_action_pressed("zoom_in_trigger"))) 
+		  and zoom < zoom_min):
 		zoom_in = true
 		zoom_out = false
 		target_zoom = zoom + Vector2(zoom_speed, zoom_speed)
 		time_lerping = 0
 
+	# pan controls:
+	# camera_pan_grab -> mouse wheel click
 	if Input.is_action_just_pressed("camera_pan_grab"):
 		panning = true
 		pan_grab_pos = event.position
@@ -45,12 +63,21 @@ func _unhandled_input(event: InputEvent):
 	elif Input.is_action_just_released("camera_pan_grab"):
 		if panning and pan_velocity != Vector2.ZERO:
 			pan_velocity = pan_velocity.normalized() * (pan_velocity.length() / pan_velocity_div_factor)
-			
 		panning = false
+	
+	# prevent zoom and pan from happening at the same time on controller
+	if !Input.is_action_pressed("zoom_trigger"):
+		camera_pan_vec = Input.get_vector("camera_pan_left", "camera_pan_right",
+										  "camera_pan_up", "camera_pan_down")
+	else:
+		camera_pan_vec = Vector2.ZERO
 
 	if Input.is_action_just_pressed("center_player"):
 		offset = Vector2.ZERO
 		pan_velocity = Vector2.ZERO
+		zoom = starting_zoom
+		zoom_in = false
+		zoom_out = false
 
 
 func _physics_process(delta: float):
@@ -67,6 +94,7 @@ func _physics_process(delta: float):
 
 
 func _process(delta):
+	# zoom logic
 	if zoom_out == true and zoom >= zoom_max:
 		time_lerping += delta
 		zoom = zoom.slerp(target_zoom, zoom_lerp_speed * delta)
@@ -79,6 +107,7 @@ func _process(delta):
 		if time_lerping >= zoom_total_time:
 			zoom_out = false
 
+	# pan logic
 	if panning:
 		var curr_mouse_pos = get_viewport().get_mouse_position()
 		offset += pan_grab_pos - curr_mouse_pos
@@ -87,3 +116,6 @@ func _process(delta):
 	if not panning:
 		offset += pan_velocity
 		pan_velocity = pan_velocity.slerp(Vector2.ZERO, pan_velocity_dampening_factor * delta)
+
+	if camera_pan_vec != Vector2.ZERO:
+		offset += camera_pan_vec.normalized() * (camera_pan_vec.length() / camera_pan_vec_div_factor)

--- a/characters/player_camera.gd
+++ b/characters/player_camera.gd
@@ -28,7 +28,7 @@ var panning: bool
 var pan_velocity: Vector2
 var pos_holder: Array = []
 var camera_pan_vec: Vector2 
-var camera_pan_vec_div_factor: float = 3 
+var camera_pan_vec_div_factor: float = 700
 
 
 func _unhandled_input(event: InputEvent):
@@ -118,4 +118,5 @@ func _process(delta):
 		pan_velocity = pan_velocity.slerp(Vector2.ZERO, pan_velocity_dampening_factor * delta)
 
 	if camera_pan_vec != Vector2.ZERO:
-		offset += camera_pan_vec.normalized() * (camera_pan_vec.length() / camera_pan_vec_div_factor)
+		print(camera_pan_vec * delta)
+		offset += camera_pan_vec.normalized() * (camera_pan_vec.length() * camera_pan_vec_div_factor * delta)

--- a/levels/planet_level/planet_level.tscn
+++ b/levels/planet_level/planet_level.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://dt7xh03ye22rr"]
+[gd_scene load_steps=8 format=3 uid="uid://dt7xh03ye22rr"]
 
 [ext_resource type="Texture2D" uid="uid://ccvnwue44mquo" path="res://levels/planet_level/planet-level-sheet.png" id="1_sucad"]
 [ext_resource type="PackedScene" uid="uid://dk0xdy43c6bcn" path="res://characters/player.tscn" id="2_didse"]
 [ext_resource type="PackedScene" uid="uid://cl4njstiybxps" path="res://ui/hud.tscn" id="3_u1381"]
+[ext_resource type="Script" path="res://characters/player_camera.gd" id="3_xh18g"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_pqjfb"]
 
@@ -66,5 +67,7 @@ position = Vector2(273, 263)
 scale = Vector2(0.2, 0.2)
 
 [node name="Camera2D" type="Camera2D" parent="player"]
+position_smoothing_enabled = true
+script = ExtResource("3_xh18g")
 
 [node name="Hud" parent="player" instance=ExtResource("3_u1381")]

--- a/project.godot
+++ b/project.godot
@@ -20,10 +20,6 @@ config/icon="res://icon.svg"
 EventService="*res://autoloads/event_service.gd"
 PauseScreen="*res://ui/pause_screen.tscn"
 
-[display]
-
-window/size/mode=3
-
 [input]
 
 ui_accept={
@@ -62,5 +58,25 @@ move_right={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
+]
+}
+zoom_in={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":4,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+zoom_out={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":5,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+center_player={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
+]
+}
+camera_pan_grab={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":3,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }

--- a/project.godot
+++ b/project.godot
@@ -73,10 +73,46 @@ zoom_out={
 center_player={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":8,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 camera_pan_grab={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":3,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+camera_pan_left={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":-1.0,"script":null)
+]
+}
+camera_pan_right={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":1.0,"script":null)
+]
+}
+camera_pan_down={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":1.0,"script":null)
+]
+}
+camera_pan_up={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":-1.0,"script":null)
+]
+}
+zoom_trigger={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
+]
+}
+zoom_in_trigger={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":-1.0,"script":null)
+]
+}
+zoom_out_trigger={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":1.0,"script":null)
 ]
 }


### PR DESCRIPTION
I thought the intention of the ticket was to adjust the camera rather than the actual game window, so I went with that.

Spent way too long getting the camera pan "velocity" to work decently, but was fun to get working. 
* Added script to Camera in `planet_level.tscn` with zoom/pan functionality
* Adjusted same Camera to use "Position Smoothing" - can also easily be turned off 
* Input mappings for zoom/pan in Project Settings: middle mouse scroll to zoom, middle mouse press to pan
* Press F to re-center the player
* Default window mode to windowed, just easier to debug, but can adjust if we want to keep fullscreen default

![Godot_v4 2 1-stable_win64_FmfcSk5rc6](https://github.com/TheAdamSmith/precursor/assets/12282139/c0ed3032-86db-41b7-9e09-173a279fc6b7)


 